### PR TITLE
fixes a crash in the demo app

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 const Koa = require('koa')
-const CSRF = require('koa-csrf').default
+const CSRF = require('koa-csrf')
 const app = new Koa()
 
 // trust proxy


### PR DESCRIPTION
CSRF has changed their module.exports procedure, so you no longer need to request the .default key.